### PR TITLE
Fixing the behavior where the runewords tooltip is appearing over the fav toggles

### DIFF
--- a/index.html
+++ b/index.html
@@ -753,7 +753,7 @@ td
         cursor    : pointer;
         visibility: visible;
         top       : 0px;
-        left      : 900px;
+        left      : 1025px;
     }
 
     .tooltip:hover .ttg
@@ -761,7 +761,7 @@ td
         cursor    : pointer;
         visibility: visible;
         top       : 0px;
-        left      : 900px;
+        left      : 1025px;
     }
 
     .tooltip:hover .ttb
@@ -769,7 +769,7 @@ td
         cursor    : pointer;
         visibility: visible;
         top       : 0px;
-        left      : 900px;
+        left      : 1025px;
     }
 
     .tooltip:hover .ttk
@@ -777,7 +777,7 @@ td
         cursor    : pointer;
         visibility: visible;
         top       : 0px;
-        left      : 900px;
+        left      : 1025px;
     }
 
 /* ----- Device ----- */


### PR DESCRIPTION
Tested on PC/Desktop on serveral resolutions.
Images below on 1600p.

**Problem:**
Crurrently when you hover the Runewords Table, the tooltip is being displayed over the fav toggles preventing to properly click on them:

![before](https://user-images.githubusercontent.com/5691887/136098175-5ee9ec02-e816-45e6-974b-380df47e7eb1.png)

**Solution:**
As we have the related table with a width of 1025px, this fix will increase de tooltip left to 1025px, ensuring it will not appear over the table anymore:

![after](https://user-images.githubusercontent.com/5691887/136098169-8d7f5924-11d8-42ba-bf70-5a68e3c1e2fd.png)