### PR TITLE
Ladder rw indicator for d2r

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,60 +4,60 @@
 
 # QoL Features
 
- * Readable on desktop and mobile
- * Interactive -- tooltips for runes and runewords (now includes Patch 2.6)
-   * Yellow highlight hover row pointer for all tables
- * click on runes to toggle "rune ownership"
-   * Clean visual rune upgrades
-   * Hover over rune to see details
-   * Rune chest dropping and farming info
-   * Hover/touch rune header for rune instructions
-   * Owned runes are remembered for the next time you (re)load the page
- * Sortable runeword table
-   * Defaults to `Owned` to see only the runewords you can make with the runes you "own"
-   * Can toggle each runeword as a favorite -- which will add it to the "rune manifest"
-   * Favorite runewords are remembered for the next time you (re)load the page
-   * Minimum runeword level
-   * Color coded offense and defense stats in runewords
-   * Alternating runeword background row colors for readability
- * Complete FCR, FHR, and FBR breakpoints
- * Collapsible tables
-    * Can collapse most of the tables, click on the `-` or `+` button in the top right of the tables (new in v1.18)
-    * Click on "Collapse" / "Expand" to collapse/expand all tables (new in 1.31)
-    * Collapse state is persistent (new in 1.84)
- * Act II Mercs
- * Area Levels
-   * Shows alvl for every difficulty & zone
-   * Shows WP icon for areas that have a waypoint
-   * Shows Terror Zone icon if that area is eligible
-   * Work-in-Progress map layout summary
-   * Color coded area levels for 83, 84, 85
-   * Color coded directions
- * Crafted Gear recipes
- * Gambling odds and few items (new in v1.33)
- * Holy Grail tracking -- no need to login, continue where you left off time you (re)load the page
-   * Can sort by Owned Misc., Owned Sets, Set Names, Owned Uniques, Unique Names, Base Name or TC
- * Essences farming
- * Pandemonium Event (key/organ farming)
- * Shopping tables
- * Tomb locations
- * Upped uniques
- * XP Tables
-    * Power Leveling
-    * Level for each difficulty & area
- * 4os sword farming
- * 85 alvl (TC 84/87) farming info  (Updated for Patch 2.4)
- * Monochrome/Color buttons
- * Lots of handy links to utils, calculators, etc.!
- * Thanks to everyone that caught bugs and offered suggestions.
+* Readable on desktop and mobile
+* Interactive -- tooltips for runes and runewords (now includes Patch 2.6)
+  * Yellow highlight hover row pointer for all tables
+* click on runes to toggle "rune ownership"
+  * Clean visual rune upgrades
+  * Hover over rune to see details
+  * Rune chest dropping and farming info
+  * Hover/touch rune header for rune instructions
+  * Owned runes are remembered for the next time you (re)load the page
+* Sortable runeword table
+  * Defaults to `Owned` to see only the runewords you can make with the runes you "own"
+  * Can toggle each runeword as a favorite -- which will add it to the "rune manifest"
+  * Favorite runewords are remembered for the next time you (re)load the page
+  * Minimum runeword level
+  * Color coded offense and defense stats in runewords
+  * Alternating runeword background row colors for readability
+* Complete FCR, FHR, and FBR breakpoints
+* Collapsible tables
+   * Can collapse most of the tables, click on the `-` or `+` button in the top right of the tables (new in v1.18)
+   * Click on "Collapse" / "Expand" to collapse/expand all tables (new in 1.31)
+   * Collapse state is persistent (new in 1.84)
+* Act II Mercs
+* Area Levels
+  * Shows alvl for every difficulty & zone
+  * Shows WP icon for areas that have a waypoint
+  * Shows Terror Zone icon if that area is eligible
+  * Work-in-Progress map layout summary
+  * Color coded area levels for 83, 84, 85
+  * Color coded directions
+* Crafted Gear recipes
+* Gambling odds and few items (new in v1.33)
+* Holy Grail tracking -- no need to login, continue where you left off time you (re)load the page
+  * Can sort by Owned Misc., Owned Sets, Set Names, Owned Uniques, Unique Names, Base Name or TC
+* Essences farming
+* Pandemonium Event (key/organ farming)
+* Shopping tables
+* Tomb locations
+* Upped uniques
+* XP Tables
+   * Power Leveling
+   * Level for each difficulty & area
+* 4os sword farming
+* 85 alvl (TC 84/87) farming info  (Updated for Patch 2.4)
+* Monochrome/Color buttons
+* Lots of handy links to utils, calculators, etc.!
+* Thanks to everyone that caught bugs and offered suggestions.
 
 
 Special thanks to walkawayy for 2.4 Runewords, Wyrda65 for updated alvl 85 info.
 
 # Wishlist
 
- * Add socket table -- Credit: soupsticle  -- https://diablo2.diablowiki.net/Sockets#Sockets_by_Number
- * Add Commonly upgraded uniques to _Upping Uniques_
+* Add socket table -- Credit: soupsticle  -- https://diablo2.diablowiki.net/Sockets#Sockets_by_Number
+* Add Commonly upgraded uniques to _Upping Uniques_
 
 ```
     Belts
@@ -107,20 +107,19 @@ Special thanks to walkawayy for 2.4 Runewords, Wyrda65 for updated alvl 85 info.
     Homunculus        : 444
 ```
 
- * Table of base/set/unique -- see https://www.reddit.com/r/Diablo/comments/q1nzh7/kudos_for_the_cheat_sheet/hfixbpm/
- * Add map layout hints -- see https://docs.google.com/spreadsheets/d/1UQP7PjHgCJWN-s42bUtGsR18f9GNh7JJ15QE7D6CnHE/edit#gid=0
- * Customize yellow hover color
- * Eth bugging def table for classic D2
- * Full xp table?
- * Table header pop-up instructions --  -- pisseningly
- * Diminishing MF -- gekido2802 -- https://diablo2.diablowiki.net/Magic_find_diminishing_returns
- * Base weapon speed mods -- Lokhe -- http://classic.battle.net/diablo2exp/items/elite/swords.shtml
- * `Layout` edit mode -- Issue #22
- * Gear Icon -- toggle scrollsbars via css -- BICEPSSSSSSSS Issue #21
+* Table of base/set/unique -- see https://www.reddit.com/r/Diablo/comments/q1nzh7/kudos_for_the_cheat_sheet/hfixbpm/
+* Add map layout hints -- see https://docs.google.com/spreadsheets/d/1UQP7PjHgCJWN-s42bUtGsR18f9GNh7JJ15QE7D6CnHE/edit#gid=0
+* Customize yellow hover color
+* Eth bugging def table for classic D2
+* Full xp table?
+* Table header pop-up instructions --  -- pisseningly
+* Diminishing MF -- gekido2802 -- https://diablo2.diablowiki.net/Magic_find_diminishing_returns
+* Base weapon speed mods -- Lokhe -- http://classic.battle.net/diablo2exp/items/elite/swords.shtml
+* `Layout` edit mode -- Issue #22
+* Gear Icon -- toggle scrollsbars via css -- BICEPSSSSSSSS Issue #21
 
 # Not Doing
 
- * url param to keep state of collapsed tables.  Not needed since table collapse state is persistent. (Fixed in version 1.84)
+* url param to keep state of collapsed tables.  Not needed since table collapse state is persistent. (Fixed in version 1.84)
 
-
-Last Updated: Sun, Feb 26, 2023.
+Last Updated: Tue, Jul 11, 2023.

--- a/index.html
+++ b/index.html
@@ -6228,7 +6228,7 @@ it now refreshes the expiration timer of the stack
 <table class='head'>
 <tr><td><b>Instructions:</b></td><td>&nbsp; Collect every <span class='misc'>misc.</span>, <span class='set'>set</span>, and <span class='unq'>unique</span> item in the game and mark when owned.</td></tr>
 <tr><td>                    </td><td>&nbsp; Click on <span class='rune'>TC</span>, <span class='rune'>Base</span>, <span class='rune'>Own</span>, <span class='rune'>Normal</span>, <span class='rune'>Set</span>, or <span class='rune'>Unique</span> to sort the Holy Grail table by that column.</td></tr>
-    <td><b>Legend:</b>      </td><td>&nbsp; q = qlvl (Quality Level); minimum item level for sets and uniques.</td></tr>
+<tr><td><b>Legend:</b>      </td><td>&nbsp; q = qlvl (Quality Level); minimum item level for sets and uniques.</td></tr>
 </table>
 <table class='head' id='table.treasureclass'>
     <tr class='yt yb b11'>

--- a/index.html
+++ b/index.html
@@ -23,8 +23,8 @@
 
     .collapse
     {
-        align  : right;
 /*
+        align  : right;
         display: inline-block;
 */
         float  : right;
@@ -51,12 +51,12 @@
     {
         content: url("pics/full_rejuv.png");
     }
-
-    // Checkboxes
+/* ----- Checkboxes  ----- */
+/*
     .hg
     {
     }
-
+*/
     .mis
     {
         color      : #F00;
@@ -426,7 +426,7 @@
 
     span.unq
     {
-        color: #AA8866; // 948064
+        color: #AA8866; /* 948064 */
     }
 
 /* ----- Span Borders for Selected/Unselected ----- */
@@ -6882,7 +6882,7 @@ it now refreshes the expiration timer of the stack
                 <tr class='pre'><td>Boss      Direction leads to mini-boss</td></tr>
                 <tr class='pre'><td><a href="https://news.blizzard.com/en-us/diablo2/23899624/diablo-ii-resurrected-ladder-season-three-now-live#Zone">TZ</a>        Every hour <b>Terror Zone</b> changes &rarr; <a href="https://d2runewizard.com/terror-zone-tracker">Tracker</a></td></tr>
             </table>
-        </td
+        </td>
     </tr>
 </table>
 <hr>

--- a/index.html
+++ b/index.html
@@ -1164,7 +1164,7 @@ var RW_COLS = [ 0, 2, 22, 25, 57, 97, 101 ]; // Runeword Recipe Columns
 //                                CLevel
 //                                    Version
 /*
- Insight             4  Polearms/Staves/Missile Weapons Ral   + Tir   + Tal  + Sol              27  1.10 lad",
+ Insight             4  Polearms/Staves/Missile Weapons Ral   + Tir   + Tal  + Sol              27  1.10 lad*",
                      ^  ^                               ^                                       ^   ^
 */
 var RECIPES = [
@@ -1219,29 +1219,29 @@ var RECIPES = [
     "  Stone               4  Body Armor                      Shael + Um    + Pul  + Lum              47  1.10",
     "  Wind                2  Melee Weapons                   Sur   + El                              61  1.10",
 
-    "  Brand               4  Missile Weapons                 Jah   + Lo    + Mal  + Gul              65  1.10 lad",
-    "  Death               5  Swords/Axes                     Hel   + El    + Vex  + Ort  + Gul       55  1.10 lad",
-    "  Destruction         5  Polearms/Swords                 Vex   + Lo    + Ber  + Jah  + Ko        65  1.10 lad",
-    "  Dragon              3  Body Armor/Shields              Sur   + Lo    + Sol                     61  1.10 lad",
-    "  Dream               3  Helms/Shields                   Io    + Jah   + Pul                     65  1.10 lad",
-    "  Edge                3  Missile Weapons                 Tir   + Tal   + Amn                     25  1.10 lad",
-    "  Faith               4  Missile Weapons                 Ohm   + Jah   + Lem  + Eld              65  1.10 lad",
-    "* Fortitude           4  Weapons/Body Armor              El    + Sol   + Dol  + Lo               59  1.10 lad",
-    "* Grief               5  Swords/Axes                     Eth   + Tir   + Lo   + Mal  + Ral       59  1.10 lad",
-    "  Harmony             4  Missile Weapons                 Tir   + Ith   + Sol  + Ko               39  1.10 lad",
-    "  Ice                 4  Missile Weapons                 Amn   + Shael + Jah  + Lo               65  1.10 lad",
-    "* Infinity            4  Polearms/Spears                 Ber   + Mal   + Ber  + Ist              63  1.10 lad",
-    "* Insight             4  Polearms/Staves/Missile Weapons Ral   + Tir   + Tal  + Sol              27  1.10 lad",
-    "* Last Wish           6  Swords/Hammers/Axes             Jah   + Mal   + Jah  + Sur  + Jah + Ber 65  1.10 lad",
-    "  Lawbringer          3  Swords/Hammers/Scepters         Amn   + Lem   + Ko                      43  1.10 lad",
-    "  Oath                4  Swords/Axes/Maces               Shael + Pul   + Mal  + Lum              49  1.10 lad",
-    "* Obedience           5  Polearms/Spears                 Hel   + Ko    + Thul + Eth  + Fal       41  1.10 lad",
-    "  Phoenix             4  Weapons/Shields                 Vex   + Vex   + Lo   + Jah              65  1.10 lad",
-    "  Pride               4  Polearms/Spears                 Cham  + Sur   + Io   + Lo               67  1.10 lad",
-    "  Rift                4  Polearms/Scepters               Hel   + Ko    + Lem  + Gul              53  1.10 lad",
-    "* Spirit              4  Swords/Shields                  Tal   + Thul  + Ort  + Amn              25  1.10 lad",
-    "  Voice of Reason     4  Swords/Maces                    Lem   + Ko    + El   + Eld              43  1.10 lad",
-    "  Wrath               4  Missile Weapons                 Pul   + Lum   + Ber  + Mal              63  1.10 lad",
+    "  Brand               4  Missile Weapons                 Jah   + Lo    + Mal  + Gul              65  1.10 lad*",
+    "  Death               5  Swords/Axes                     Hel   + El    + Vex  + Ort  + Gul       55  1.10 lad*",
+    "  Destruction         5  Polearms/Swords                 Vex   + Lo    + Ber  + Jah  + Ko        65  1.10 lad*",
+    "  Dragon              3  Body Armor/Shields              Sur   + Lo    + Sol                     61  1.10 lad*",
+    "  Dream               3  Helms/Shields                   Io    + Jah   + Pul                     65  1.10 lad*",
+    "  Edge                3  Missile Weapons                 Tir   + Tal   + Amn                     25  1.10 lad*",
+    "  Faith               4  Missile Weapons                 Ohm   + Jah   + Lem  + Eld              65  1.10 lad*",
+    "* Fortitude           4  Weapons/Body Armor              El    + Sol   + Dol  + Lo               59  1.10 lad*",
+    "* Grief               5  Swords/Axes                     Eth   + Tir   + Lo   + Mal  + Ral       59  1.10 lad*",
+    "  Harmony             4  Missile Weapons                 Tir   + Ith   + Sol  + Ko               39  1.10 lad*",
+    "  Ice                 4  Missile Weapons                 Amn   + Shael + Jah  + Lo               65  1.10 lad*",
+    "* Infinity            4  Polearms/Spears                 Ber   + Mal   + Ber  + Ist              63  1.10 lad*",
+    "* Insight             4  Polearms/Staves/Missile Weapons Ral   + Tir   + Tal  + Sol              27  1.10 lad*",
+    "* Last Wish           6  Swords/Hammers/Axes             Jah   + Mal   + Jah  + Sur  + Jah + Ber 65  1.10 lad*",
+    "  Lawbringer          3  Swords/Hammers/Scepters         Amn   + Lem   + Ko                      43  1.10 lad*",
+    "  Oath                4  Swords/Axes/Maces               Shael + Pul   + Mal  + Lum              49  1.10 lad*",
+    "* Obedience           5  Polearms/Spears                 Hel   + Ko    + Thul + Eth  + Fal       41  1.10 lad*",
+    "  Phoenix             4  Weapons/Shields                 Vex   + Vex   + Lo   + Jah              65  1.10 lad*",
+    "  Pride               4  Polearms/Spears                 Cham  + Sur   + Io   + Lo               67  1.10 lad*",
+    "  Rift                4  Polearms/Scepters               Hel   + Ko    + Lem  + Gul              53  1.10 lad*",
+    "* Spirit              4  Swords/Shields                  Tal   + Thul  + Ort  + Amn              25  1.10 lad*",
+    "  Voice of Reason     4  Swords/Maces                    Lem   + Ko    + El   + Eld              43  1.10 lad*",
+    "  Wrath               4  Missile Weapons                 Pul   + Lum   + Ber  + Mal              63  1.10 lad*",
 
     "  Bone                3  Body Armor                      Sol   + Um    + Um                      47  1.11",
     "  Enlightenment       3  Body Armor                      Pul   + Ral   + Sol                     45  1.11",
@@ -1251,22 +1251,22 @@ var RECIPES = [
     "  Rain                3  Body Armor                      Ort   + Mal   + Ith                     49  1.11",
     "* Treachery           3  Body Armor                      Shael + Thul  + Lem                     43  1.11",
 
-    "  Flickering Flame    3  Helms                           Nef   + Pul   + Vex                     55  2.4 lad",
-    "  Mist                5  Missile Weapons                 Cham  + Shael + Gul  + Thul + Ith       67  2.4 lad",
-    "  Obsession           6  Staves                          Zod   + Ist   + Lem  + Lum  + Io  + Nef 69  2.4 lad",
-    "  Pattern             3  Claws                           Tal   + Ort   + Thul                    23  2.4 lad",
-    "  Plague              3  Swords/Claws/Daggers            Cham  + Shael + Um                      67  2.4 lad",
-    "  Unbending Will      6  Swords                          Fal   + Io    + Ith  + Eld  + El  + Hel 41  2.4 lad",
-    "  Wisdom              3  Helms                           Pul   + Ith   + Eld                     45  2.4 lad",
+    "  Flickering Flame    3  Helms                           Nef   + Pul   + Vex                     55  2.4 lad*",
+    "  Mist                5  Missile Weapons                 Cham  + Shael + Gul  + Thul + Ith       67  2.4 lad*",
+    "  Obsession           6  Staves                          Zod   + Ist   + Lem  + Lum  + Io  + Nef 69  2.4 lad*",
+    "  Pattern             3  Claws                           Tal   + Ort   + Thul                    23  2.4 lad*",
+    "  Plague              3  Swords/Claws/Daggers            Cham  + Shael + Um                      67  2.4 lad*",
+    "  Unbending Will      6  Swords                          Fal   + Io    + Ith  + Eld  + El  + Hel 41  2.4 lad*",
+    "  Wisdom              3  Helms                           Pul   + Ith   + Eld                     45  2.4 lad*",
 
-    "  Bulwark             3  Helms                           Shael + Io    + Sol                     35  2.6",
-    "  Cure                3  Helms                           Shael + Io    + Tal                     35  2.6",
-    "  Ground              3  Helms                           Shael + Io    + Ort                     35  2.6",
-    "  Hearth              3  Helms                           Shael + Io    + Thul                    35  2.6",
-    "  Temper              3  Helms                           Shael + Io    + Ral                     35  2.6",
-    "  Hustle              3  Body Armor/Weapons              Shael + Ko    + Eld                     39  2.6",
-    "* Mosaic              3  Claw                            Mal   + Gul   + Amn                     53  2.6",
-    "  Metamorphosis       3  Helm                            Io    + Cham  + Fal                     67  2.6"
+    "  Bulwark             3  Helms                           Shael + Io    + Sol                     35  2.6 lad",
+    "  Cure                3  Helms                           Shael + Io    + Tal                     35  2.6 lad",
+    "  Ground              3  Helms                           Shael + Io    + Ort                     35  2.6 lad",
+    "  Hearth              3  Helms                           Shael + Io    + Thul                    35  2.6 lad",
+    "  Temper              3  Helms                           Shael + Io    + Ral                     35  2.6 lad",
+    "  Hustle              3  Body Armor/Weapons              Shael + Ko    + Eld                     39  2.6 lad",
+    "* Mosaic              3  Claw                            Mal   + Gul   + Amn                     53  2.6 lad",
+    "  Metamorphosis       3  Helm                            Io    + Cham  + Fal                     67  2.6 lad"
 ];
 
     const HolyGrailColumn =
@@ -3261,10 +3261,10 @@ function updateRuneWordsOrder( array )
         var ver   = gaRuneWordVer[ array[ row-1 ] ];
         var is109 = ver.indexOf( '1.09'     ) === 0; // r
         var is110 = ver.indexOf( '1.10'     ) === 0; // g
-        var isLad = ver.indexOf( '1.10 lad' ) === 0; // b
+        var isLad = ver.indexOf( '1.10 lad*') === 0; // b
         var is111 = ver.indexOf( '1.11'     ) === 0; // k
-        var is24  = ver.indexOf( '2.4 lad'  ) === 0; // y
-        var is26  = ver.indexOf( '2.6'      ) === 0; // g
+        var is24  = ver.indexOf( '2.4 lad*' ) === 0; // y
+        var is26  = ver.indexOf( '2.6 lad'  ) === 0; // g
 
 
              if( is111 ) _addClasses( elem, isOdd ? 'k11' : 'k22' );
@@ -4664,6 +4664,9 @@ for chests to drop this rune<br>
 <br>
 </div>
 <b>Rune Manifest for Fav. Runewords:</b><br><span class='pre column1' id='manifest'><br><br><br></span>
+<table class='head'>
+<tr><td><b>Version:</b>      </td><td>&nbsp; lad* runewords can be made by D2R single-player and non-ladder characters.</td></tr>
+</table>
 <!-- ========== ========== ========== ========== Runewords ========== ========== ========== ========== -->
 <table class='head' id='table.runeWords'>
     <tr class='rt rb'><th><div><span class='rwu' id='btnRuneWordSuperior'><span onclick='onSortRuneWordsBySuperior();'>S</span></span> <span class='rwu' id='btnRuneWordNames'><span onclick='onSortRuneWordsByName();'>Name</span></span>          <span class='rwu' id='btnRuneWordSockets'><span onclick='onSortRuneWordsBySocket();'>Sockets</span></span>  <span class='rwu' id='btnRuneWordType'><span onclick='onSortRuneWordsByType();'>Type</span></span>                      <span class='rwu' id='btnRuneWordOwned'><span onclick='onSortRuneWordsByOwned();'>Owned</span></span> <span class='rwu' id='btnRuneWordMats1'><span onclick='onSortRuneWordsByMats(1);'>Runes</span></span>   <span class='rwu' id='btnRuneWordMats2'><span onclick='onSortRuneWordsByMats(2);'>#2</span></span>      <span class='rwu' id='btnRuneWordMats3'><span onclick='onSortRuneWordsByMats(3);'>#3</span></span>     <span class='rwu' id='btnRuneWordMats4'><span onclick='onSortRuneWordsByMats(4);'>#4</span></span>    <span class='rwu' id='btnRuneWordMats5'><span onclick='onSortRuneWordsByMats(5);'>#5</span></span>    <span class='rwu' id='btnRuneWordMats6'><span onclick='onSortRuneWordsByMats(6);'>#6</span></span>  <span class='rwu' id='btnRuneWordLevel'><span onclick='onSortRuneWordsByLevel();'>Lev</span></span>  Fav <span class='rws' id='btnRuneWordVersion'><span onclick='onSortRuneWordsByVersion();'>Version</span></span><div class='collapse'><button value='table.runeWords' onclick='onCollapse(this);'>-</button></div></div></th></tr>
@@ -5291,7 +5294,7 @@ for chests to drop this rune<br>
  Level 13 Twister (127 Charges)
  </span></td></tr>
 <!-- ========== ========== ========== ========== Runewords 1.10 Ladder ========== ========== ========== ==========-->
-<tr id='rw48'><td class='tooltip'><span class="rw-text b11">  Brand               4  Missile Weapons                 Jah   + Lo    + Mal  + Gul              65  <button type='button' id='fav48' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad</span><span class='tool ttb'>Jah <img src='runes/jah.png'  /> + Lo <img src='runes/lo.png'   /> + Mal <img src='runes/mal.png'  /> + Gul <img src='runes/gul.png'  />
+<tr id='rw48'><td class='tooltip'><span class="rw-text b11">  Brand               4  Missile Weapons                 Jah   + Lo    + Mal  + Gul              65  <button type='button' id='fav48' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad*</span><span class='tool ttb'>Jah <img src='runes/jah.png'  /> + Lo <img src='runes/lo.png'   /> + Mal <img src='runes/mal.png'  /> + Gul <img src='runes/gul.png'  />
 
  35% Chance To Cast Level 14 Amplify Damage When Struck
  100% Chance To Cast Level 18 Bone Spear On Striking
@@ -5304,7 +5307,7 @@ for chests to drop this rune<br>
  Knockback
  Fires Explosive Arrows or Bolts (15)
  </span></td></tr>
-<tr id='rw49'><td class='tooltip'><span class="rw-text b22">  Death               5  Swords/Axes                     Hel   + El    + Vex  + Ort  + Gul       55  <button type='button' id='fav49' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad</span><span class='tool ttb'>Hel <img src='runes/hel.png'  /> + El <img src='runes/el.png'   /> + Vex <img src='runes/vex.png'  /> + Ort <img src='runes/ort.png'  /> + Gul <img src='runes/gul.png'  />
+<tr id='rw49'><td class='tooltip'><span class="rw-text b22">  Death               5  Swords/Axes                     Hel   + El    + Vex  + Ort  + Gul       55  <button type='button' id='fav49' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad*</span><span class='tool ttb'>Hel <img src='runes/hel.png'  /> + El <img src='runes/el.png'   /> + Vex <img src='runes/vex.png'  /> + Ort <img src='runes/ort.png'  /> + Gul <img src='runes/gul.png'  />
 
  100% Chance To Cast Level 44 Chain Lightning When You Die
  25% Chance To Cast Level 18 Glacial Spike On Attack
@@ -5320,7 +5323,7 @@ for chests to drop this rune<br>
  Level 22 Blood Golem (15 Charges)
  Requirements -20%
  </span></td></tr>
-<tr id='rw50'><td class='tooltip'><span class="rw-text b11">  Destruction         5  Polearms/Swords                 Vex   + Lo    + Ber  + Jah  + Ko        65  <button type='button' id='fav50' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad</span><span class='tool ttb'>Vex <img src='runes/vex.png'  /> + Lo <img src='runes/lo.png'   /> + Ber <img src='runes/ber.png'  /> + Jah <img src='runes/jah.png'  /> + Ko <img src='runes/ko.png'   />
+<tr id='rw50'><td class='tooltip'><span class="rw-text b11">  Destruction         5  Polearms/Swords                 Vex   + Lo    + Ber  + Jah  + Ko        65  <button type='button' id='fav50' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad*</span><span class='tool ttb'>Vex <img src='runes/vex.png'  /> + Lo <img src='runes/lo.png'   /> + Ber <img src='runes/ber.png'  /> + Jah <img src='runes/jah.png'  /> + Ko <img src='runes/ko.png'   />
 
  23% Chance To Cast Level 12 Volcano On Striking
  5% Chance To Cast Level 23 Molten Boulder On Striking
@@ -5335,7 +5338,7 @@ for chests to drop this rune<br>
  Prevent Monster Heal
  +10 To Dexterity
  </span></td></tr>
-<tr id='rw51'><td class='tooltip'><span class="rw-text b22">  Dragon              3  Body Armor/Shields              Sur   + Lo    + Sol                     61  <button type='button' id='fav51' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad</span><span class='tool ttb'>Sur <img src='runes/sur.png'  /> + Lo <img src='runes/lo.png'   /> + Sol <img src='runes/sol.png'  />
+<tr id='rw51'><td class='tooltip'><span class="rw-text b22">  Dragon              3  Body Armor/Shields              Sur   + Lo    + Sol                     61  <button type='button' id='fav51' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad*</span><span class='tool ttb'>Sur <img src='runes/sur.png'  /> + Lo <img src='runes/lo.png'   /> + Sol <img src='runes/sol.png'  />
 
  20% Chance to Cast Level 18 Venom When Struck
  12% Chance To Cast Level 15 Hydra On Striking
@@ -5349,7 +5352,7 @@ for chests to drop this rune<br>
  +5% To Maximum Lightning Resist
  Damage Reduced by <span class='dr'>7</span>
  </span></td></tr>
-<tr id='rw52'><td class='tooltip'><span class="rw-text b11">  Dream               3  Helms/Shields                   Io    + Jah   + Pul                     65  <button type='button' id='fav52' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad</span><span class='tool ttb'>Io <img src='runes/io.png'   /> + Jah <img src='runes/jah.png'  /> + Pul <img src='runes/pul.png'  />
+<tr id='rw52'><td class='tooltip'><span class="rw-text b11">  Dream               3  Helms/Shields                   Io    + Jah   + Pul                     65  <button type='button' id='fav52' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad*</span><span class='tool ttb'>Io <img src='runes/io.png'   /> + Jah <img src='runes/jah.png'  /> + Pul <img src='runes/pul.png'  />
 
  10% Chance To Cast Level 15 Confuse When Struck
  Level 15 Holy Shock Aura When Equipped
@@ -5363,7 +5366,7 @@ for chests to drop this rune<br>
  All Resistances +<span class='resa'>5-20</span> (varies)
  <span class='mf'>12</span>-<span class='mf'>25</span>% Better Chance of Getting Magic Items (varies)
  </span></td></tr>
-<tr id='rw53'><td class='tooltip'><span class="rw-text b22">  Edge                3  Missile Weapons                 Tir   + Tal   + Amn                     25  <button type='button' id='fav53' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad</span><span class='tool ttb'>Tir <img src='runes/tir.png'  /> + Tal <img src='runes/tal.png'  /> + Amn <img src='runes/amn.png'  />
+<tr id='rw53'><td class='tooltip'><span class="rw-text b22">  Edge                3  Missile Weapons                 Tir   + Tal   + Amn                     25  <button type='button' id='fav53' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad*</span><span class='tool ttb'>Tir <img src='runes/tir.png'  /> + Tal <img src='runes/tal.png'  /> + Amn <img src='runes/amn.png'  />
 
  Level 15 Thorns Aura When Equipped
  +<span class='ias'>35</span>% Increased Attack Speed
@@ -5376,7 +5379,7 @@ for chests to drop this rune<br>
  +2 To Mana After Each Kill
  Reduces All Vendor Prices <span class='gold'>15</span>%
  </span></td></tr>
-<tr id='rw54'><td class='tooltip'><span class="rw-text b11">  Faith               4  Missile Weapons                 Ohm   + Jah   + Lem  + Eld              65  <button type='button' id='fav54' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad</span><span class='tool ttb'>Ohm <img src='runes/ohm.png'  /> + Jah <img src='runes/jah.png'  /> + Lem <img src='runes/lem.png'  /> + Eld <img src='runes/eld.png'  />
+<tr id='rw54'><td class='tooltip'><span class="rw-text b11">  Faith               4  Missile Weapons                 Ohm   + Jah   + Lem  + Eld              65  <button type='button' id='fav54' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad*</span><span class='tool ttb'>Ohm <img src='runes/ohm.png'  /> + Jah <img src='runes/jah.png'  /> + Lem <img src='runes/lem.png'  /> + Eld <img src='runes/eld.png'  />
 
  Level 12-15 Fanaticism Aura When Equipped (varies)
  <span class='skill'>+1-2 To All Skills</span> (varies)
@@ -5396,7 +5399,7 @@ for chests to drop this rune<br>
  <b>4os Bases for Merc</b>
  Great Bow
  </span></td></tr>
-<tr id='rw55'><td class='tooltip'><span class="rw-text b22">* Fortitude           4  Weapons/Body Armor              El    + Sol   + Dol  + Lo               59  <button type='button' id='fav55' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad</span><span class='tool ttb'>El <img src='runes/el.png'   /> + Sol <img src='runes/sol.png'  /> + Dol <img src='runes/dol.png'  /> + Lo <img src='runes/lo.png'   />
+<tr id='rw55'><td class='tooltip'><span class="rw-text b22">* Fortitude           4  Weapons/Body Armor              El    + Sol   + Dol  + Lo               59  <button type='button' id='fav55' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad*</span><span class='tool ttb'>El <img src='runes/el.png'   /> + Sol <img src='runes/sol.png'  /> + Dol <img src='runes/dol.png'  /> + Lo <img src='runes/lo.png'   />
 
  <b>Weapons</b>
  20% Chance To Cast Level 15 Chilling Armor when Struck
@@ -5436,7 +5439,7 @@ for chests to drop this rune<br>
  Eth Lacquered Plate (433-541 def)
  Eth Hellforge Plate (421-530 def)
  </span></td></tr>
-<tr id='rw56'><td class='tooltip'><span class="rw-text b11">* Grief               5  Swords/Axes                     Eth   + Tir   + Lo   + Mal  + Ral       59  <button type='button' id='fav56' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad</span><span class='tool ttb'>Eth <img src='runes/eth.png'  /> + Tir <img src='runes/tir.png'  /> + Lo <img src='runes/lo.png'   /> + Mal <img src='runes/mal.png'  /> + Ral <img src='runes/ral.png'  />
+<tr id='rw56'><td class='tooltip'><span class="rw-text b11">* Grief               5  Swords/Axes                     Eth   + Tir   + Lo   + Mal  + Ral       59  <button type='button' id='fav56' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad*</span><span class='tool ttb'>Eth <img src='runes/eth.png'  /> + Tir <img src='runes/tir.png'  /> + Lo <img src='runes/lo.png'   /> + Mal <img src='runes/mal.png'  /> + Ral <img src='runes/ral.png'  />
 
  35% Chance To Cast Level 15 Venom On Striking
  +<span class='ias'>30</span>-<span class='ias'>40</span>% Increased Attack Speed (varies)
@@ -5451,7 +5454,7 @@ for chests to drop this rune<br>
  +2 To Mana After Each Kill
  +10-15 Life After Each Kill (varies)
  </span></td></tr>
-<tr id='rw57'><td class='tooltip'><span class="rw-text b22">  Harmony             4  Missile Weapons                 Tir   + Ith   + Sol  + Ko               39  <button type='button' id='fav57' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad</span><span class='tool ttb'>Tir <img src='runes/tir.png'  /> + Ith <img src='runes/ith.png'  /> + Sol <img src='runes/sol.png'  /> + Ko <img src='runes/ko.png'   />
+<tr id='rw57'><td class='tooltip'><span class="rw-text b22">  Harmony             4  Missile Weapons                 Tir   + Ith   + Sol  + Ko               39  <button type='button' id='fav57' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad*</span><span class='tool ttb'>Tir <img src='runes/tir.png'  /> + Ith <img src='runes/ith.png'  /> + Sol <img src='runes/sol.png'  /> + Ko <img src='runes/ko.png'   />
 
  Level 10 Vigor Aura When Equipped
  +200-275% Enhanced Damage (varies)
@@ -5467,7 +5470,7 @@ for chests to drop this rune<br>
  +2 To Light Radius
  Level 20 Revive (25 Charges)
  </span></td></tr>
-<tr id='rw58'><td class='tooltip'><span class="rw-text b11">  Ice                 4  Missile Weapons                 Amn   + Shael + Jah  + Lo               65  <button type='button' id='fav58' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad</span><span class='tool ttb'>Amn <img src='runes/amn.png'  /> + Shael <img src='runes/shael.png'/> + Jah <img src='runes/jah.png'  /> + Lo <img src='runes/lo.png'   />
+<tr id='rw58'><td class='tooltip'><span class="rw-text b11">  Ice                 4  Missile Weapons                 Amn   + Shael + Jah  + Lo               65  <button type='button' id='fav58' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad*</span><span class='tool ttb'>Amn <img src='runes/amn.png'  /> + Shael <img src='runes/shael.png'/> + Jah <img src='runes/jah.png'  /> + Lo <img src='runes/lo.png'   />
 
  100% Chance To Cast Level 40 Blizzard When You Level-up
  25% Chance To Cast Level 22 Frost Nova On Striking
@@ -5481,7 +5484,7 @@ for chests to drop this rune<br>
  <span class='ds'>20</span>% Deadly Strike
  <span class='gold'>3.125</span>-<span class='gold'>309.375</span> Extra Gold From Monsters<br> (Based on Character Level)
  </span></td></tr>
-<tr id='rw59'><td class='tooltip'><span class="rw-text b22">* Infinity            4  Polearms/Spears                 Ber   + Mal   + Ber  + Ist              63  <button type='button' id='fav59' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad</span><span class='tool ttb'>Ber <img alt='Ber' src='runes/ber.png'  /> + Mal <img alt='Mal' src='runes/mal.png'  /> + Ber <img src='runes/ber.png'  /> + Ist <img src='runes/ist.png'  />
+<tr id='rw59'><td class='tooltip'><span class="rw-text b22">* Infinity            4  Polearms/Spears                 Ber   + Mal   + Ber  + Ist              63  <button type='button' id='fav59' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad*</span><span class='tool ttb'>Ber <img alt='Ber' src='runes/ber.png'  /> + Mal <img alt='Mal' src='runes/mal.png'  /> + Ber <img src='runes/ber.png'  /> + Ist <img src='runes/ist.png'  />
 
  50% Chance To Cast Level 20 Chain Lightning When You Kill An Enemy
  Level 12 Conviction Aura When Equipped
@@ -5494,7 +5497,7 @@ for chests to drop this rune<br>
  <span class='mf'>30</span>% Better Chance of Getting Magic Items
  Level 21 Cyclone Armor (30 Charges)
  </span></td></tr>
-<tr id='rw60'><td class='tooltip'><span class="rw-text b11">* Insight             4  Polearms/Staves/Missile Weapons Ral   + Tir   + Tal  + Sol              27  <button type='button' id='fav60' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad</span><span class='tool ttb'>Ral <img alt='Ral' src='runes/ral.png'  /> + Tir <img alt='Tir' src='runes/tir.png'  /> + Tal <img src='runes/tal.png'  /> + Sol <img src='runes/sol.png'  />
+<tr id='rw60'><td class='tooltip'><span class="rw-text b11">* Insight             4  Polearms/Staves/Missile Weapons Ral   + Tir   + Tal  + Sol              27  <button type='button' id='fav60' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad*</span><span class='tool ttb'>Ral <img alt='Ral' src='runes/ral.png'  /> + Tir <img alt='Tir' src='runes/tir.png'  /> + Tal <img src='runes/tal.png'  /> + Sol <img src='runes/sol.png'  />
 
  Level 12-17 Meditation Aura When Equipped (varies)
  +<span class='fcr'>35</span>% Faster Cast Rate
@@ -5508,7 +5511,7 @@ for chests to drop this rune<br>
  +2 To Mana After Each Kill
  <span class='mf'>23</span>% Better Chance of Getting Magic Items
  </span></td></tr>
-<tr id='rw61'><td class='tooltip'><span class="rw-text b22">* Last Wish           6  Swords/Hammers/Axes             Jah   + Mal   + Jah  + Sur  + Jah + Ber 65  <button type='button' id='fav61' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad</span><span class='tool ttb'>Jah <img alt='Jah' src='runes/jah.png'  /> + Mal <img alt='Mal' src='runes/mal.png'  /> + Jah <img src='runes/jah.png'  /> + Sur <img src='runes/sur.png'  /> + Jah <img src='runes/jah.png'  /> + Ber <img src='runes/ber.png'  />
+<tr id='rw61'><td class='tooltip'><span class="rw-text b22">* Last Wish           6  Swords/Hammers/Axes             Jah   + Mal   + Jah  + Sur  + Jah + Ber 65  <button type='button' id='fav61' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad*</span><span class='tool ttb'>Jah <img alt='Jah' src='runes/jah.png'  /> + Mal <img alt='Mal' src='runes/mal.png'  /> + Jah <img src='runes/jah.png'  /> + Sur <img src='runes/sur.png'  /> + Jah <img src='runes/jah.png'  /> + Ber <img src='runes/ber.png'  />
 
  6% Chance To Cast Level 11 Fade When Struck
  10% Chance To Cast Level 18 Life Tap On Striking
@@ -5521,7 +5524,7 @@ for chests to drop this rune<br>
  Hit Blinds Target
  +(<span class='mf'>0.5</span> per character level) <span class='mf'>0.5</span>-<span class='mf'>49.5</span>% Chance of Getting Magic Items<br> (Based on Character Level)
  </span></td></tr>
-<tr id='rw62'><td class='tooltip'><span class="rw-text b11">  Lawbringer          3  Swords/Hammers/Scepters         Amn   + Lem   + Ko                      43  <button type='button' id='fav62' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad</span><span class='tool ttb'>Amn <img alt='Amn' src='runes/amn.png'  /> + Lem <img src='runes/lem.png'  /> + Ko <img src='runes/ko.png'   />
+<tr id='rw62'><td class='tooltip'><span class="rw-text b11">  Lawbringer          3  Swords/Hammers/Scepters         Amn   + Lem   + Ko                      43  <button type='button' id='fav62' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad*</span><span class='tool ttb'>Amn <img alt='Amn' src='runes/amn.png'  /> + Lem <img src='runes/lem.png'  /> + Ko <img src='runes/ko.png'   />
 
  20% Chance To Cast Level 15 Decrepify On Striking
  Level 16-18 Sanctuary Aura When Equipped (varies)
@@ -5534,7 +5537,7 @@ for chests to drop this rune<br>
  +10 To Dexterity
  <span class='gold'>75</span>% Extra Gold From Monsters
  </span></td></tr>
-<tr id='rw63'><td class='tooltip'><span class="rw-text b22">  Oath                4  Swords/Axes/Maces               Shael + Pul   + Mal  + Lum              49  <button type='button' id='fav63' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad</span><span class='tool ttb'>Shael <img alt='Shael' src='runes/shael.png'/> + Pul <img alt='Pul' src='runes/pul.png'  /> + Mal <img alt='Mal' src='runes/mal.png'  /> + Lum <img alt='Lum' src='runes/lum.png'  />
+<tr id='rw63'><td class='tooltip'><span class="rw-text b22">  Oath                4  Swords/Axes/Maces               Shael + Pul   + Mal  + Lum              49  <button type='button' id='fav63' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad*</span><span class='tool ttb'>Shael <img alt='Shael' src='runes/shael.png'/> + Pul <img alt='Pul' src='runes/pul.png'  /> + Mal <img alt='Mal' src='runes/mal.png'  /> + Lum <img alt='Lum' src='runes/lum.png'  />
 
  30% Chance To Cast Level 20 Bone Spirit On Striking
  Indestructible
@@ -5548,7 +5551,7 @@ for chests to drop this rune<br>
  Level 16 Heart Of Wolverine (20 Charges)
  Level 17 Iron Golem (14 Charges)
  </span></td></tr>
-<tr id='rw64'><td class='tooltip'><span class="rw-text b11">* Obedience           5  Polearms/Spears                 Hel   + Ko    + Thul + Eth  + Fal       41  <button type='button' id='fav64' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad</span><span class='tool ttb'>Hel <img alt='Hel' src='runes/hel.png'  /> + Ko <img alt='Ko' src='runes/ko.png'   /> + Thul <img alt='Thul' src='runes/thul.png' /> + Eth <img alt='Eth' src='runes/eth.png'  /> + Fal <img alt='Fal' src='runes/fal.png'  />
+<tr id='rw64'><td class='tooltip'><span class="rw-text b11">* Obedience           5  Polearms/Spears                 Hel   + Ko    + Thul + Eth  + Fal       41  <button type='button' id='fav64' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad*</span><span class='tool ttb'>Hel <img alt='Hel' src='runes/hel.png'  /> + Ko <img alt='Ko' src='runes/ko.png'   /> + Thul <img alt='Thul' src='runes/thul.png' /> + Eth <img alt='Eth' src='runes/eth.png'  /> + Fal <img alt='Fal' src='runes/fal.png'  />
 
  30% Chance To Cast Level 21 Enchant When You Kill An Enemy
  <span class='fhr'>40</span>% Faster Hit Recovery
@@ -5563,7 +5566,7 @@ for chests to drop this rune<br>
  All Resistances +<span class='resa'>20-30</span> (varies)
  Requirements -20%
  </span></td></tr>
-<tr id='rw65'><td class='tooltip'><span class="rw-text b22">  Phoenix             4  Weapons/Shields                 Vex   + Vex   + Lo   + Jah              65  <button type='button' id='fav65' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad</span><span class='tool ttb'>Vex <img alt='Vex' src='runes/vex.png'  /> + Vex <img alt='Vex' src='runes/vex.png'  /> + Lo <img alt='Lo' src='runes/lo.png'   /> + Jah <img alt='Jah' src='runes/jah.png'  />
+<tr id='rw65'><td class='tooltip'><span class="rw-text b22">  Phoenix             4  Weapons/Shields                 Vex   + Vex   + Lo   + Jah              65  <button type='button' id='fav65' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad*</span><span class='tool ttb'>Vex <img alt='Vex' src='runes/vex.png'  /> + Vex <img alt='Vex' src='runes/vex.png'  /> + Lo <img alt='Lo' src='runes/lo.png'   /> + Jah <img alt='Jah' src='runes/jah.png'  />
  <b>Weapons</b>
  100% Chance To Cast level 40 Blaze When You Level-up
  40% Chance To Cast Level 22 Firestorm On Striking
@@ -5588,7 +5591,7 @@ for chests to drop this rune<br>
  +10% To Maximum Fire Resist
  +15-21 Fire Absorb (varies)
  </span></td></tr>
-<tr id='rw66'><td class='tooltip'><span class="rw-text b11">  Pride               4  Polearms/Spears                 Cham  + Sur   + Io   + Lo               67  <button type='button' id='fav66' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad</span><span class='tool ttb'>Cham <img alt='Cham' src='runes/cham.png' /> + Sur <img alt='Sur' src='runes/sur.png'  /> + Io <img alt='Io' src='runes/io.png'   /> + Lo <img alt='Lo' src='runes/lo.png'   />
+<tr id='rw66'><td class='tooltip'><span class="rw-text b11">  Pride               4  Polearms/Spears                 Cham  + Sur   + Io   + Lo               67  <button type='button' id='fav66' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad*</span><span class='tool ttb'>Cham <img alt='Cham' src='runes/cham.png' /> + Sur <img alt='Sur' src='runes/sur.png'  /> + Io <img alt='Io' src='runes/io.png'   /> + Lo <img alt='Lo' src='runes/lo.png'   />
 
  25% Chance To Cast Level 17 Fire Wall When Struck
  Level 16-20 Concentration Aura When Equipped (varies)
@@ -5602,7 +5605,7 @@ for chests to drop this rune<br>
  Replenish Life +8
  <span class='gold'>1.875</span>-<span class='gold'>185.625</span>% Extra Gold From Monsters<br> (Based on Character Level)
  </span></td></tr>
-<tr id='rw67'><td class='tooltip'><span class="rw-text b22">  Rift                4  Polearms/Scepters               Hel   + Ko    + Lem  + Gul              53  <button type='button' id='fav67' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad</span><span class='tool ttb'>Hel <img alt='Hel' src='runes/hel.png'  /> + Ko <img alt='Ko' src='runes/ko.png'   /> + Lem <img alt='Lem' src='runes/lem.png'  /> + Gul <img alt='Gul' src='runes/gul.png'  />
+<tr id='rw67'><td class='tooltip'><span class="rw-text b22">  Rift                4  Polearms/Scepters               Hel   + Ko    + Lem  + Gul              53  <button type='button' id='fav67' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad*</span><span class='tool ttb'>Hel <img alt='Hel' src='runes/hel.png'  /> + Ko <img alt='Ko' src='runes/ko.png'   /> + Lem <img alt='Lem' src='runes/lem.png'  /> + Gul <img alt='Gul' src='runes/gul.png'  />
 
  20% Chance To Cast Level 16 Tornado On Striking
  16% Chance To Cast Level 21 Frozen Orb On Attack
@@ -5616,7 +5619,7 @@ for chests to drop this rune<br>
  Level 15 Iron Maiden (40 Charges)
  Requirements -20%
  </span></td></tr>
-<tr id='rw68'><td class='tooltip'><span class="rw-text b11">* Spirit              4  Swords/Shields                  Tal   + Thul  + Ort  + Amn              25  <button type='button' id='fav68' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad</span><span class='tool ttb'>Tal <img alt='Tal' src='runes/tal.png'  /> + Thul <img alt='Thul' src='runes/thul.png' /> + Ort <img alt='Ort' src='runes/ort.png'  /> + Amn <img alt='Amn' src='runes/amn.png'  />
+<tr id='rw68'><td class='tooltip'><span class="rw-text b11">* Spirit              4  Swords/Shields                  Tal   + Thul  + Ort  + Amn              25  <button type='button' id='fav68' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad*</span><span class='tool ttb'>Tal <img alt='Tal' src='runes/tal.png'  /> + Thul <img alt='Thul' src='runes/thul.png' /> + Ort <img alt='Ort' src='runes/ort.png'  /> + Amn <img alt='Amn' src='runes/amn.png'  />
 
  <b>Weapons</b>
  <span class='skill'>+2 To All Skills</span>
@@ -5647,7 +5650,7 @@ for chests to drop this rune<br>
  <b>4os Bases for Player</b>
  Crystal Sword
  </span></td></tr>
-<tr id='rw69'><td class='tooltip'><span class="rw-text b22">  Voice of Reason     4  Swords/Maces                    Lem   + Ko    + El   + Eld              43  <button type='button' id='fav69' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad</span><span class='tool ttb'>Lem <img alt='Lem' src='runes/lem.png'  /> + Ko <img alt='Ko' src='runes/ko.png'   /> + El <img alt='El' src='runes/el.png'   /> + Eld <img alt='Eld' src='runes/eld.png'  />
+<tr id='rw69'><td class='tooltip'><span class="rw-text b22">  Voice of Reason     4  Swords/Maces                    Lem   + Ko    + El   + Eld              43  <button type='button' id='fav69' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad*</span><span class='tool ttb'>Lem <img alt='Lem' src='runes/lem.png'  /> + Ko <img alt='Ko' src='runes/ko.png'   /> + El <img alt='El' src='runes/el.png'   /> + Eld <img alt='Eld' src='runes/eld.png'  />
 
  15% Chance To Cast Level 13 Frozen Orb On Striking
  18% Chance To Cast Level 20 Ice Blast On Striking
@@ -5662,7 +5665,7 @@ for chests to drop this rune<br>
  <span class='gold'>75</span>% Extra Gold From Monsters
  +1 To Light Radius
  </span></td></tr>
-<tr id='rw70'><td class='tooltip'><span class="rw-text b11">  Wrath               4  Missile Weapons                 Pul   + Lum   + Ber  + Mal              63  <button type='button' id='fav70' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad</span><span class='tool ttb'>Pul <img alt='Pul' src='runes/pul.png'  /> + Lum <img alt='Lum' src='runes/lum.png'  /> + Ber <img alt='Ber' src='runes/ber.png'  /> + Mal <img alt='Mal' src='runes/mal.png'  />
+<tr id='rw70'><td class='tooltip'><span class="rw-text b11">  Wrath               4  Missile Weapons                 Pul   + Lum   + Ber  + Mal              63  <button type='button' id='fav70' onclick='onToggleFavRW(this);'>&#x2610;</button> 1.10 lad*</span><span class='tool ttb'>Pul <img alt='Pul' src='runes/pul.png'  /> + Lum <img alt='Lum' src='runes/lum.png'  /> + Ber <img alt='Ber' src='runes/ber.png'  /> + Mal <img alt='Mal' src='runes/mal.png'  />
 
  30% Chance To Cast Level 1 Decrepify On Striking
  5% Chance To Cast Level 10 Life Tap On Striking
@@ -5748,7 +5751,7 @@ for chests to drop this rune<br>
  </span></td></tr>
 <!-- ========== ========== ========== ========== Runewords 2.4 Ladder ========== ========== ========== ==========-->
 
-<tr id='rw78'><td class='tooltip'><span class="rw-text y22">  Flickering Flame    3  Helms                           Nef   + Pul   + Vex                     55  <button type='button' id='fav78' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.4  lad</span><span class='tool ttk'>Nef <img src='runes/nef.png'/> + Pul <img src='runes/pul.png' /> + Vex <img src='runes/vex.png'  />
+<tr id='rw78'><td class='tooltip'><span class="rw-text y22">  Flickering Flame    3  Helms                           Nef   + Pul   + Vex                     55  <button type='button' id='fav78' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.4  lad*</span><span class='tool ttk'>Nef <img src='runes/nef.png'/> + Pul <img src='runes/pul.png' /> + Vex <img src='runes/vex.png'  />
 
  Level 4-8 Resist Fire Aura When Equipped (varies)
  +3 To Fire Skills
@@ -5760,7 +5763,7 @@ for chests to drop this rune<br>
  +5% To Maximum Fire Resist
  Poison Length Reduced by 50%
  </span></td></tr>
-<tr id='rw79'><td class='tooltip'><span class="rw-text y11">  Mist                5  Missile Weapons                 Cham  + Shael + Gul  + Thul + Ith       67  <button type='button' id='fav79' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.4  lad</span><span class='tool ttk'>Cham <img src='runes/cham.png'/> + Shael <img src='runes/shael.png' /> + Gul <img src='runes/gul.png' /> + Thul <img src='runes/thul.png' /> + Ith <img src='runes/ith.png'  />
+<tr id='rw79'><td class='tooltip'><span class="rw-text y11">  Mist                5  Missile Weapons                 Cham  + Shael + Gul  + Thul + Ith       67  <button type='button' id='fav79' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.4  lad*</span><span class='tool ttk'>Cham <img src='runes/cham.png'/> + Shael <img src='runes/shael.png' /> + Gul <img src='runes/gul.png' /> + Thul <img src='runes/thul.png' /> + Ith <img src='runes/ith.png'  />
 
  Level 8-12 Concentration Aura When Equipped (varies)
  +3 To All Skills
@@ -5774,7 +5777,7 @@ for chests to drop this rune<br>
  +24 Vitality
  All Resistances +<span class='resa'>40</span>
  </span></td></tr>
-<tr id='rw80'><td class='tooltip'><span class="rw-text y22">  Obsession           6  Staves                          Zod   + Ist   + Lem  + Lum  + Io  + Nef 69  <button type='button' id='fav80' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.4  lad</span><span class='tool ttk'>Zod <img src='runes/zod.png'/> + Ist <img src='runes/ist.png' /> + Lem <img src='runes/lem.png' /> + Lum <img src='runes/lum.png' /> + Io <img src='runes/io.png' /> + Nef <img src='runes/nef.png'  />
+<tr id='rw80'><td class='tooltip'><span class="rw-text y22">  Obsession           6  Staves                          Zod   + Ist   + Lem  + Lum  + Io  + Nef 69  <button type='button' id='fav80' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.4  lad*</span><span class='tool ttk'>Zod <img src='runes/zod.png'/> + Ist <img src='runes/ist.png' /> + Lem <img src='runes/lem.png' /> + Lum <img src='runes/lum.png' /> + Io <img src='runes/io.png' /> + Nef <img src='runes/nef.png'  />
 
  Indestructible
  24% Chance to cast level 10 Weaken when struck
@@ -5790,7 +5793,7 @@ for chests to drop this rune<br>
  <span class='gold'>75</span>% Extra Gold From Monsters
  <span class='mf'>30</span>% Better Chance of Getting Magic Items
  </span></td></tr>
-<tr id='rw81'><td class='tooltip'><span class="rw-text y11">  Pattern             3  Claws                           Tal   + Ort   + Thul                    23  <button type='button' id='fav81' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.4  lad</span><span class='tool ttk'>Tal <img src='runes/tal.png'/> + Ort <img src='runes/ort.png' /> + Thul <img src='runes/thul.png'  />
+<tr id='rw81'><td class='tooltip'><span class="rw-text y11">  Pattern             3  Claws                           Tal   + Ort   + Thul                    23  <button type='button' id='fav81' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.4  lad*</span><span class='tool ttk'>Tal <img src='runes/tal.png'/> + Ort <img src='runes/ort.png' /> + Thul <img src='runes/thul.png'  />
 
  +<span class='fbr'>30</span>% Faster Block Rate
  +40-80% Enhanced Damage (varies)
@@ -5803,7 +5806,7 @@ for chests to drop this rune<br>
  +6 to Dexterity
  All Resistances +<span class='resa'>15</span>
  </span></td></tr>
-<tr id='rw82'><td class='tooltip'><span class="rw-text y22">  Plague              3  Swords/Claws/Daggers            Cham  + Shael + Um                      67  <button type='button' id='fav82' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.4  lad</span><span class='tool ttk'>Cham <img src='runes/cham.png'/> + Shael <img src='runes/shael.png' /> + Um <img src='runes/um.png'  />
+<tr id='rw82'><td class='tooltip'><span class="rw-text y22">  Plague              3  Swords/Claws/Daggers            Cham  + Shael + Um                      67  <button type='button' id='fav82' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.4  lad*</span><span class='tool ttk'>Cham <img src='runes/cham.png'/> + Shael <img src='runes/shael.png' /> + Um <img src='runes/um.png'  />
 
  20% Chance to cast level 12 Lower Resist when struck
  25% Chance to cast level 15 Poison Nova on striking
@@ -5817,7 +5820,7 @@ for chests to drop this rune<br>
  +25% Chance of Open Wounds
  Freezes Target +3
  </span></td></tr>
-<tr id='rw83'><td class='tooltip'><span class="rw-text y11">  Unbending Will      6  Swords                          Fal   + Io    + Ith  + Eld  + El  + Hel 41  <button type='button' id='fav83' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.4  lad</span><span class='tool ttk'>Fal <img src='runes/fal.png'/> + Io <img src='runes/io.png' /> + Ith <img src='runes/ith.png' /> + Eld <img src='runes/eld.png' /> + El <img src='runes/el.png' /> + Hel <img src='runes/hel.png'  />
+<tr id='rw83'><td class='tooltip'><span class="rw-text y11">  Unbending Will      6  Swords                          Fal   + Io    + Ith  + Eld  + El  + Hel 41  <button type='button' id='fav83' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.4  lad*</span><span class='tool ttk'>Fal <img src='runes/fal.png'/> + Io <img src='runes/io.png' /> + Ith <img src='runes/ith.png' /> + Eld <img src='runes/eld.png' /> + El <img src='runes/el.png' /> + Hel <img src='runes/hel.png'  />
 
  18% Chance to cast Level 18 Taunt on striking
  +3 To Combat Skills (Barbarian Only)
@@ -5835,7 +5838,7 @@ for chests to drop this rune<br>
  +1 Light Radius
  Requirements -20%
  </span></td></tr>
-<tr id='rw84'><td class='tooltip'><span class="rw-text y22">  Wisdom              3  Helms                           Pul   + Ith   + Eld                     45  <button type='button' id='fav84' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.4  lad</span><span class='tool ttk'>Pul <img src='runes/pul.png'/> + Ith <img src='runes/ith.png' /> + Eld <img src='runes/eld.png'  />
+<tr id='rw84'><td class='tooltip'><span class="rw-text y22">  Wisdom              3  Helms                           Pul   + Ith   + Eld                     45  <button type='button' id='fav84' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.4  lad*</span><span class='tool ttk'>Pul <img src='runes/pul.png'/> + Ith <img src='runes/ith.png' /> + Eld <img src='runes/eld.png'  />
 
  +33% Piercing Attack
  +15-25% Bonus to Attack Rating (varies)
@@ -5847,7 +5850,7 @@ for chests to drop this rune<br>
  +5 Mana After Each Kill
  15% Damage Taken Goes to Mana
  </span></td></tr>
-<tr id='rw85'><td class='tooltip'><span class="rw-text g22">  Bulwark             3  Helms                           Shael + Io    + Sol                     35  <button type='button' id='fav85' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6</span><span class='tool ttk'>Shael<img src='runes/shael.png'/> + Io <img src='runes/io.png' /> + Sol<img src='runes/sol.png'  />
+<tr id='rw85'><td class='tooltip'><span class="rw-text g22">  Bulwark             3  Helms                           Shael + Io    + Sol                     35  <button type='button' id='fav85' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6  lad</span><span class='tool ttk'>Shael<img src='runes/shael.png'/> + Io <img src='runes/io.png' /> + Sol<img src='runes/sol.png'  />
 
  +<span class='fhr'>20</span>% Faster Hit Recovery
  +4-6% Life stolen per hit
@@ -5858,7 +5861,7 @@ for chests to drop this rune<br>
  Damage Reduced by <span class='dr'>7</span>
  Physical Damage Received Reduced by 10-15%
 </span></td></tr>
-<tr id='rw86'><td class='tooltip'><span class="rw-text g22">  Cure                3  Helms                           Shael + Io    + Tal                     35  <button type='button' id='fav86' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6</span><span class='tool ttk'>Shael<img src='runes/shael.png'/> + Io <img src='runes/io.png' /> + Tal<img src='runes/tal.png'  />
+<tr id='rw86'><td class='tooltip'><span class="rw-text g22">  Cure                3  Helms                           Shael + Io    + Tal                     35  <button type='button' id='fav86' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6  lad</span><span class='tool ttk'>Shael<img src='runes/shael.png'/> + Io <img src='runes/io.png' /> + Tal<img src='runes/tal.png'  />
 
  Level 1 Cleansing Aura when Equipped
  +<span class='fhr'>20</span>% Faster Hit Recovery
@@ -5868,7 +5871,7 @@ for chests to drop this rune<br>
  Poison Resist +<span class='resp'>40</span>-<span class='resp'>60</span>%
  Poison Length Reduced by 50%
 </span></td></tr>
-<tr id='rw87'><td class='tooltip'><span class="rw-text g22">  Ground              3  Helms                           Shael + Io    + Ort                     35  <button type='button' id='fav87' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6</span><span class='tool ttk'>Shael<img src='runes/shael.png'/> + Io <img src='runes/io.png' /> + Ort<img src='runes/ort.png'  />
+<tr id='rw87'><td class='tooltip'><span class="rw-text g22">  Ground              3  Helms                           Shael + Io    + Ort                     35  <button type='button' id='fav87' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6  lad</span><span class='tool ttk'>Shael<img src='runes/shael.png'/> + Io <img src='runes/io.png' /> + Ort<img src='runes/ort.png'  />
 
  +<span class='fhr'>20</span>% Faster Hit Recovery
  +75-100% Enhanced Defense
@@ -5877,7 +5880,7 @@ for chests to drop this rune<br>
  Lightning Resist +<span class='resl'>40</span>-<span class='resl'>60</span>%
  Lightning Absorb +10-15%
 </span></td></tr>
-<tr id='rw88'><td class='tooltip'><span class="rw-text g22">  Hearth              3  Helms                           Shael + Io    + Thul                    35  <button type='button' id='fav88' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6</span><span class='tool ttk'>Shael<img src='runes/shael.png'/> + Io <img src='runes/io.png' /> + Thul<img src='runes/thul.png'  />
+<tr id='rw88'><td class='tooltip'><span class="rw-text g22">  Hearth              3  Helms                           Shael + Io    + Thul                    35  <button type='button' id='fav88' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6  lad</span><span class='tool ttk'>Shael<img src='runes/shael.png'/> + Io <img src='runes/io.png' /> + Thul<img src='runes/thul.png'  />
 
  +<span class='fhr'>20</span>% Faster Hit Recovery
  +75-100% Enhanced Defense
@@ -5887,7 +5890,7 @@ for chests to drop this rune<br>
  Cold Absorb +10-15%
  <span class='cbf'>Cannot Be Frozen</span>
 </span></td></tr>
-<tr id='rw89'><td class='tooltip'><span class="rw-text g22">  Temper              3  Helms                           Shael + Io    + Ral                     35  <button type='button' id='fav89' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6</span><span class='tool ttk'>Shael<img src='runes/shael.png'/> + Io <img src='runes/io.png' /> + Ral<img src='runes/ral.png'  />
+<tr id='rw89'><td class='tooltip'><span class="rw-text g22">  Temper              3  Helms                           Shael + Io    + Ral                     35  <button type='button' id='fav89' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6  lad</span><span class='tool ttk'>Shael<img src='runes/shael.png'/> + Io <img src='runes/io.png' /> + Ral<img src='runes/ral.png'  />
 
  +<span class='fhr'>20</span>% Faster Hit Recovery
  +75-100% Enhanced Defense
@@ -5896,7 +5899,7 @@ for chests to drop this rune<br>
  Fire Resist +<span class='resf'>40</span>-<span class='resf'>60</span>%
  Fire Absorb +10-15%
 </span></td></tr>
-<tr id='rw90'><td class='tooltip'><span class="rw-text g22">  Hustle              3  Body Armor/Weapons              Shael + Ko    + Eld                     39  <button type='button' id='fav90' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6</span><span class='tool ttk'>Shael<img src='runes/shael.png'/> + Ko <img src='runes/ko.png' /> + Eld<img src='runes/eld.png'  />
+<tr id='rw90'><td class='tooltip'><span class="rw-text g22">  Hustle              3  Body Armor/Weapons              Shael + Ko    + Eld                     39  <button type='button' id='fav90' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6  lad</span><span class='tool ttk'>Shael<img src='runes/shael.png'/> + Ko <img src='runes/ko.png' /> + Eld<img src='runes/eld.png'  />
 
 <b>Armor</b>
  +65% Faster Run/Walk
@@ -5916,7 +5919,7 @@ Level 1 Fanaticism Aura
 +50 to Attack Rating against Undead
 +10 to Dexterity
 </span></td></tr>
-<tr id='rw91'><td class='tooltip'><span class="rw-text g22">* Mosaic              3  Claw                            Mal   + Gul   + Amn                     53  <button type='button' id='fav91' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6</span><span class='tool ttk'>Mal<img src='runes/mal.png'/> + Gul <img src='runes/gul.png' /> + Amn<img src='runes/amn.png'  />
+<tr id='rw91'><td class='tooltip'><span class="rw-text g22">* Mosaic              3  Claw                            Mal   + Gul   + Amn                     53  <button type='button' id='fav91' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6  lad</span><span class='tool ttk'>Mal<img src='runes/mal.png'/> + Gul <img src='runes/gul.png' /> + Amn<img src='runes/amn.png'  />
 
  +50% +25% chance for finishing moves to not consume charges
  When a finisher is executed this way,
@@ -5932,7 +5935,7 @@ it now refreshes the expiration timer of the stack
  +8-15% to Fire Skill Damage
  Prevent Monster Heal
 </span></td></tr>
-<tr id='rw92'><td class='tooltip'><span class="rw-text g22">  Metamorphosis       3  Helm                            Io    + Cham  + Fal                     67  <button type='button' id='fav92' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6</span><span class='tool ttk'>Io<img src='runes/io.png'/> + Cham <img src='runes/cham.png' /> + Fal<img src='runes/fal.png'  />
+<tr id='rw92'><td class='tooltip'><span class="rw-text g22">  Metamorphosis       3  Helm                            Io    + Cham  + Fal                     67  <button type='button' id='fav92' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6  lad</span><span class='tool ttk'>Io<img src='runes/io.png'/> + Cham <img src='runes/cham.png' /> + Fal<img src='runes/fal.png'  />
 
  Werewolf strikes grant Mark for 180 seconds
  <b>Mark of the Wolf</b>:
@@ -7033,6 +7036,7 @@ Thanks:
   * WildBohemian            for catching   Hit Power Shields copy/paste hackjob.
   * hyperactiveChipmunk     for catching   Kurast Docks typo
   * Korndaweizen            for fixing     Runewords z-order with missing runes on mobile.
+  * sir-wilhelm             for tweaking   of runeword ladder labels/minor HTML fix
 </pre>
 <h2 id='thoughts'>My Thoughts on Diablo 2, Diablo 3, Diablo 4, and other ARPGs.</h2>
 Quick summary of popular ARPGs:
@@ -7204,7 +7208,7 @@ Yes, goblins exist in D4:
 </pre>
 
 <hr class='one'>
-<span style='font-size:12px;'>Version <a href="https://github.com/Michaelangel007/d2_cheat_sheet/commits">1.89</a>, Last Updated Sun, Jul 9, 2023.</span>
+<span style='font-size:12px;'>Version <a href="https://github.com/Michaelangel007/d2_cheat_sheet/commits">1.90</a>, Last Updated Tue, Jul 11, 2023.</span>
 <span style='font-size:10px;'>CSS Debug: Screen Size:</span> <span id='screen-size'>?</span>, <span class='ios-hidden' >iOS-hidden</span> <span class='ios-visible'>iOS-visible</span>
 <span style='font-size:6px;'>All bugs are due to Anthony slacking on QA.</span>
 </div></body>


### PR DESCRIPTION
This adds an indicator for RWs that can be crafted in single-player/non-ladder for D2R.

It's a potential fix for https://github.com/Michaelangel007/d2_cheat_sheet/issues/46 while waiting for https://github.com/Michaelangel007/d2_cheat_sheet/issues/35.