### PR TITLE
Give new/alternating row colors for the 2.6 ladder RWs.

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,6 +135,16 @@
         background-color: #431; /* F4E4B7 653; */
     }
 
+    .p11
+    {
+        background-color: #303;
+    }
+
+    .p22
+    {
+        background-color: #202;
+    }
+
     /* Tiers */
     .stier { color: #000; background-color: hsl(  0 100% 75%); } /* rgb(255, 127, 127); */
     .atier { color: #000; background-color: hsl( 30 100% 75%); } /* rgb(255, 191, 127); */
@@ -6035,7 +6045,7 @@ for chests to drop this rune<br>
  +5 Mana After Each Kill
  15% Damage Taken Goes to Mana
  </span></td></tr>
-<tr id='rw85'><td class='tooltip'><span class="rw-text g22">  Bulwark             3  Helms                           Shael + Io    + Sol                     35  <button type='button' id='fav85' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6</span><span class='tool ttk'>Shael<img src='runes/shael.png'/> + Io <img src='runes/io.png' /> + Sol<img src='runes/sol.png'  />
+<tr id='rw85'><td class='tooltip'><span class="rw-text p11">  Bulwark             3  Helms                           Shael + Io    + Sol                     35  <button type='button' id='fav85' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6</span><span class='tool ttk'>Shael<img src='runes/shael.png'/> + Io <img src='runes/io.png' /> + Sol<img src='runes/sol.png'  />
 
  +<span class='fhr'>20</span>% Faster Hit Recovery
  +4-6% Life stolen per hit
@@ -6046,7 +6056,7 @@ for chests to drop this rune<br>
  Damage Reduced by <span class='dr'>7</span>
  Physical Damage Received Reduced by 10-15%
 </span></td></tr>
-<tr id='rw86'><td class='tooltip'><span class="rw-text g22">  Cure                3  Helms                           Shael + Io    + Tal                     35  <button type='button' id='fav86' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6</span><span class='tool ttk'>Shael<img src='runes/shael.png'/> + Io <img src='runes/io.png' /> + Tal<img src='runes/tal.png'  />
+<tr id='rw86'><td class='tooltip'><span class="rw-text p22">  Cure                3  Helms                           Shael + Io    + Tal                     35  <button type='button' id='fav86' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6</span><span class='tool ttk'>Shael<img src='runes/shael.png'/> + Io <img src='runes/io.png' /> + Tal<img src='runes/tal.png'  />
 
  Level 1 Cleansing Aura when Equipped
  +<span class='fhr'>20</span>% Faster Hit Recovery
@@ -6056,7 +6066,7 @@ for chests to drop this rune<br>
  Poison Resist +<span class='resp'>40</span>-<span class='resp'>60</span>%
  Poison Length Reduced by 50%
 </span></td></tr>
-<tr id='rw87'><td class='tooltip'><span class="rw-text g22">  Ground              3  Helms                           Shael + Io    + Ort                     35  <button type='button' id='fav87' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6</span><span class='tool ttk'>Shael<img src='runes/shael.png'/> + Io <img src='runes/io.png' /> + Ort<img src='runes/ort.png'  />
+<tr id='rw87'><td class='tooltip'><span class="rw-text p11">  Ground              3  Helms                           Shael + Io    + Ort                     35  <button type='button' id='fav87' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6</span><span class='tool ttk'>Shael<img src='runes/shael.png'/> + Io <img src='runes/io.png' /> + Ort<img src='runes/ort.png'  />
 
  +<span class='fhr'>20</span>% Faster Hit Recovery
  +75-100% Enhanced Defense
@@ -6065,7 +6075,7 @@ for chests to drop this rune<br>
  Lightning Resist +<span class='resl'>40</span>-<span class='resl'>60</span>%
  Lightning Absorb +10-15%
 </span></td></tr>
-<tr id='rw88'><td class='tooltip'><span class="rw-text g22">  Hearth              3  Helms                           Shael + Io    + Thul                    35  <button type='button' id='fav88' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6</span><span class='tool ttk'>Shael<img src='runes/shael.png'/> + Io <img src='runes/io.png' /> + Thul<img src='runes/thul.png'  />
+<tr id='rw88'><td class='tooltip'><span class="rw-text p22">  Hearth              3  Helms                           Shael + Io    + Thul                    35  <button type='button' id='fav88' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6</span><span class='tool ttk'>Shael<img src='runes/shael.png'/> + Io <img src='runes/io.png' /> + Thul<img src='runes/thul.png'  />
 
  +<span class='fhr'>20</span>% Faster Hit Recovery
  +75-100% Enhanced Defense
@@ -6075,7 +6085,7 @@ for chests to drop this rune<br>
  Cold Absorb +10-15%
  <span class='cbf'>Cannot Be Frozen</span>
 </span></td></tr>
-<tr id='rw89'><td class='tooltip'><span class="rw-text g22">  Temper              3  Helms                           Shael + Io    + Ral                     35  <button type='button' id='fav89' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6</span><span class='tool ttk'>Shael<img src='runes/shael.png'/> + Io <img src='runes/io.png' /> + Ral<img src='runes/ral.png'  />
+<tr id='rw89'><td class='tooltip'><span class="rw-text p11">  Temper              3  Helms                           Shael + Io    + Ral                     35  <button type='button' id='fav89' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6</span><span class='tool ttk'>Shael<img src='runes/shael.png'/> + Io <img src='runes/io.png' /> + Ral<img src='runes/ral.png'  />
 
  +<span class='fhr'>20</span>% Faster Hit Recovery
  +75-100% Enhanced Defense
@@ -6084,7 +6094,7 @@ for chests to drop this rune<br>
  Fire Resist +<span class='resf'>40</span>-<span class='resf'>60</span>%
  Fire Absorb +10-15%
 </span></td></tr>
-<tr id='rw90'><td class='tooltip'><span class="rw-text g22">  Hustle              3  Body Armor/Weapons              Shael + Ko    + Eld                     39  <button type='button' id='fav90' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6</span><span class='tool ttk'>Shael<img src='runes/shael.png'/> + Ko <img src='runes/ko.png' /> + Eld<img src='runes/eld.png'  />
+<tr id='rw90'><td class='tooltip'><span class="rw-text p22">  Hustle              3  Body Armor/Weapons              Shael + Ko    + Eld                     39  <button type='button' id='fav90' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6</span><span class='tool ttk'>Shael<img src='runes/shael.png'/> + Ko <img src='runes/ko.png' /> + Eld<img src='runes/eld.png'  />
 
 <b>Armor</b>
  +65% Faster Run/Walk
@@ -6104,7 +6114,7 @@ Level 1 Fanaticism Aura
 +50 to Attack Rating against Undead
 +10 to Dexterity
 </span></td></tr>
-<tr id='rw91'><td class='tooltip'><span class="rw-text g22">* Mosaic              3  Claw                            Mal   + Gul   + Amn                     53  <button type='button' id='fav91' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6</span><span class='tool ttk'>Mal<img src='runes/mal.png'/> + Gul <img src='runes/gul.png' /> + Amn<img src='runes/amn.png'  />
+<tr id='rw91'><td class='tooltip'><span class="rw-text p11">* Mosaic              3  Claw                            Mal   + Gul   + Amn                     53  <button type='button' id='fav91' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6</span><span class='tool ttk'>Mal<img src='runes/mal.png'/> + Gul <img src='runes/gul.png' /> + Amn<img src='runes/amn.png'  />
 
  +50% +25% chance for finishing moves to not consume charges
  When a finisher is executed this way,
@@ -6120,7 +6130,7 @@ it now refreshes the expiration timer of the stack
  +8-15% to Fire Skill Damage
  Prevent Monster Heal
 </span></td></tr>
-<tr id='rw92'><td class='tooltip'><span class="rw-text g22">  Metamorphosis       3  Helm                            Io    + Cham  + Fal                     67  <button type='button' id='fav92' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6</span><span class='tool ttk'>Io<img src='runes/io.png'/> + Cham <img src='runes/cham.png' /> + Fal<img src='runes/fal.png'  />
+<tr id='rw92'><td class='tooltip'><span class="rw-text p22">  Metamorphosis       3  Helm                            Io    + Cham  + Fal                     67  <button type='button' id='fav92' onclick='onToggleFavRW(this);'>&#x2610;</button> 2.6</span><span class='tool ttk'>Io<img src='runes/io.png'/> + Cham <img src='runes/cham.png' /> + Fal<img src='runes/fal.png'  />
 
  Werewolf strikes grant Mark for 180 seconds
  <b>Mark of the Wolf</b>:


### PR DESCRIPTION
resolves #60

when sorted by version:
current:
![image](https://github.com/Michaelangel007/d2_cheat_sheet/assets/3122458/ff1bed5c-01d4-4366-bbdf-a14282fc08d0)

suggested:
![image](https://github.com/Michaelangel007/d2_cheat_sheet/assets/3122458/82ef0c27-48ec-406c-bf6c-614150778546)
