### PR TITLE
Update D2R terror zone duration

### DIFF
--- a/index.html
+++ b/index.html
@@ -7510,7 +7510,7 @@ Good:
 * Gamepad support
 * Cross-platform online characters
 * Extended Character Details panel
-* Terror Zones (random zone every 30 mins is at max level of that difficulty)
+* Terror Zones (random zone every hour is at max level of that difficulty)
 
 Bad:
 


### PR DESCRIPTION
AFAIK, zones are terrorized for an hour, not for 30m. I've only been playing for a few weeks; perhaps the duration was changed from 30m to 1h in an earlier patch.

P.S. Your cheat sheet is a work of art.